### PR TITLE
handle bad data to find more matching departures

### DIFF
--- a/src/api/TrainAnnouncement.ts
+++ b/src/api/TrainAnnouncement.ts
@@ -1,5 +1,7 @@
 export type TrainAnnouncement = {
   LocationSignature: string;
+  FromLocation: Location[];
+  ViaFromLocation: Location[];
   ToLocation: Location[];
   ViaToLocation: Location[];
   TimeAtLocation?: string;
@@ -21,6 +23,8 @@ export type MetaInformation = { Code: string; Description: string; };
 
 export const trainAnnouncementModel: Required<TrainAnnouncement> = {
   LocationSignature: "",
+  FromLocation: [],
+  ViaFromLocation: [],
   ToLocation: [],
   ViaToLocation: [],
   TimeAtLocation: "2022-05-14T07:37:00.000+02:00",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,35 @@ export const fetchTrafikInfo = async ({
   fromTime,
   toTime,
 }: FetchTrafikInfoConfig) => {
+
+  // Some train announcements don't include all the "via from" and "via to" stations
+  // so we need to fetch all announcements for the time period and look for the
+  // ones that include both stations in some valid arrangement. And then we can
+  // use the train IDs to get the departures we are actually interested in.
+
+  const allAnnouncements = await fetchAnnouncements([
+    timeFilter(fromTime, toTime),
+    stationFilter(departureLocation, arrivalLocation),
+  ]);
+
+  const advertisedTrainAnnouncements = allAnnouncements
+    .filter(ta => ta.Advertised)
+    .filter(ta => !ta.ProductInformation?.some(pi => pi.Description === "Museitåg"));
+
+  const trainIDs = new Set(advertisedTrainAnnouncements.map(ta => ta.AdvertisedTrainIdent));
+
+  // Now we can fetch all the departures for the relevant train IDs from the given station.
+  const filteredAnnouncements = await fetchAnnouncements([
+    `<EQ name='ActivityType' value='Avgang' />`,
+    `<EQ name='LocationSignature' value='${departureLocation}' />`,
+    timeFilter(fromTime, toTime),
+    trainIdFilter(trainIDs),
+  ]);
+
+  return filteredAnnouncements;
+}
+
+const fetchAnnouncements = async (andFilters: string[]): Promise<TrainAnnouncement[]> => {
   const result = await fetch(
     "https://api.trafikinfo.trafikverket.se/v2/data.json",
     {
@@ -23,10 +52,7 @@ export const fetchTrafikInfo = async ({
           <QUERY objecttype='TrainAnnouncement' schemaversion='1.6'>
             <FILTER>
               <AND>
-                <EQ name='LocationSignature' value='${departureLocation}' />
-                <EQ name='ActivityType' value='Avgang' />
-                <GT name='AdvertisedTimeAtLocation' value='${fromTime}'/>
-                <LT name='AdvertisedTimeAtLocation' value='${toTime}'/>
+                ${andFilters.join('')}
               </AND>
             </FILTER>
             ${
@@ -34,20 +60,69 @@ export const fetchTrafikInfo = async ({
                 .map(key=> `<INCLUDE>${key}</INCLUDE>`)
                 .join("\n")
              }
+
           </QUERY>
-        </REQUEST>`,
+        </REQUEST>
+      `,
       headers: {
         "Content-Type": "application/xml",
         Accept: "application/json",
       },
     }
-  )
+  );
+
   const { RESPONSE } = await result.json();
-  const announcements = RESPONSE.RESULT[0].TrainAnnouncement as TrainAnnouncement[];
-  return announcements
-    .filter(ta => ta.Advertised && (
-      ta.ToLocation?.some(tl => tl.LocationName === arrivalLocation)
-      || ta.ViaToLocation?.some(vtl => vtl.LocationName === arrivalLocation)
-      // :shrug:
-    ) && !ta.ProductInformation?.some(pi => pi.Description === "Museitåg"))
+  const trainAnnouncements = RESPONSE.RESULT[0].TrainAnnouncement;
+  return trainAnnouncements;
+}
+
+function timeFilter(fromTime: string, toTime: string): string {
+  return `
+    <AND>
+      <GT name='AdvertisedTimeAtLocation' value='${fromTime}'/>
+      <LT name='AdvertisedTimeAtLocation' value='${toTime}'/>
+    </AND>
+  `;
+}
+
+function trainIdFilter(trainIds: Set<string>): string {
+  return `
+    <OR>
+      ${Array.from(trainIds).map(id => `<EQ name='AdvertisedTrainIdent' value='${id}' />`).join("\n")}
+    </OR>
+  `;
+}
+
+// This is a bit of a hack, but it's because the data can be inconsistent,
+// sometimes the ViaFromLocation or ViaToLocation is not included.
+function stationFilter(fromStation: string, toStation: string): string {
+  // Try to find all relevant announcements for a given departure from "LocationSignature".
+  const fromStationFilter = `
+    <AND>
+      <EQ name='LocationSignature' value='${fromStation}' />
+      <EQ name='ActivityType' value='Avgang' />
+      <OR>
+        <EQ name='ToLocation.LocationName' value='${toStation}' />
+        <EQ name='ViaToLocation.LocationName' value='${toStation}' />
+      </OR>
+    </AND>
+  `;
+  // Try to find all relevant announcements for a given arrival at "LocationSignature".
+  const toStationFilter = `
+    <AND>
+      <EQ name='LocationSignature' value='${toStation}' />
+      <EQ name='ActivityType' value='Ankomst' />
+      <OR>
+        <EQ name='FromLocation.LocationName' value='${fromStation}' />
+        <EQ name='ViaFromLocation.LocationName' value='${fromStation}' />
+      </OR>
+    </AND>
+  `;
+
+  return `
+    <OR>
+      ${fromStationFilter}
+      ${toStationFilter}
+    </OR>
+  `;
 }


### PR DESCRIPTION
Problem
======

Some announcements pass through stations (such as Stockholm C) on the way to their final destination (such as Arboga) without listing them in `ViaToLocation` in the departure announcement (from e.g. Uppsala).

See #2

A Solution Proposal
==============

I don't think it's possible to do this in one single API query without it basically being `all trains that depart from A OR that arrive at B` which would be a lot of announcements.

But we can do two queries to find all the departures from A stopping at B:
1. Find all trains that depart from A either to B or "via to" B, or that arrive at B either from A or "via from" A.
2. Find all departures from A where the train ID is in the response from 1.

This does not guarantee all bad data is handled, but it does handle the known case of train 919 which is missing correct `ViaToLocation`. And it's (I believe) not _that_ ugly of a hack.

Notes
=====

The first request only needs the train identifiers but the code is simpler if it doesn't need to also parameterize the `<INCLUDE>` selectors. It's not a huge response anyway.